### PR TITLE
Debian does not support podman secret

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -30,7 +30,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.tcp-ports-demand=2" \
     --label="org.nethserver.rootfull=0" \
     --label="org.nethserver.authorizations=traefik@any:routeadm" \
-    --label="org.nethserver.images=docker.io/mariadb:10.6.5 docker.io/phpmyadmin/phpmyadmin:5.1.1" \
+    --label="org.nethserver.images=docker.io/mariadb:10.6.5 docker.io/phpmyadmin/phpmyadmin:5.1.3" \
     "${container}"
 # Commit everything
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/imageroot/actions/configure-module/02create_secrets
+++ b/imageroot/actions/configure-module/02create_secrets
@@ -26,12 +26,9 @@ if [[ ! -d ~/.config/state/secrets ]]; then
     /usr/bin/mkdir -p ~/.config/state/secrets
 fi
 
-if [[ ! -f ~/.config/state/secrets/phpmyadmin.secret ]]; then
+if [[ ! -f ~/.config/state/secrets/passwords.secret ]]; then
     password_phpmyadmin=$(/usr/bin/openssl rand -hex 20)
-    /usr/bin/echo "MARIADB_PASSWORD=$password_phpmyadmin" > ~/.config/state/secrets/phpmyadmin.secret
-fi
-
-if [[ ! -f ~/.config/state/secrets/root.secret ]]; then
     password_root=$(/usr/bin/openssl rand -hex 20)
-    /usr/bin/echo "MARIADB_ROOT_PASSWORD=$password_root" > ~/.config/state/secrets/root.secret
+    /usr/bin/echo "MARIADB_PASSWORD=$password_phpmyadmin
+    MARIADB_ROOT_PASSWORD=$password_root" > ~/.config/state/secrets/passwords.secret
 fi

--- a/imageroot/actions/configure-module/02create_secrets
+++ b/imageroot/actions/configure-module/02create_secrets
@@ -28,12 +28,10 @@ fi
 
 if [[ ! -f ~/.config/state/secrets/phpmyadmin.secret ]]; then
     password_phpmyadmin=$(/usr/bin/openssl rand -hex 20)
-    /usr/bin/echo $password_phpmyadmin > ~/.config/state/secrets/phpmyadmin.secret
-    /usr/bin/podman secret create phpmyadmin.secret ~/.config/state/secrets/phpmyadmin.secret
+    /usr/bin/echo "MARIADB_PASSWORD=$password_phpmyadmin" > ~/.config/state/secrets/phpmyadmin.secret
 fi
 
 if [[ ! -f ~/.config/state/secrets/root.secret ]]; then
     password_root=$(/usr/bin/openssl rand -hex 20)
-    /usr/bin/echo $password_root > ~/.config/state/secrets/root.secret
-    /usr/bin/podman secret create root.secret ~/.config/state/secrets/root.secret
+    /usr/bin/echo "MARIADB_ROOT_PASSWORD=$password_root" > ~/.config/state/secrets/root.secret
 fi

--- a/imageroot/systemd/user/mariadb-app.service
+++ b/imageroot/systemd/user/mariadb-app.service
@@ -6,6 +6,8 @@ After=mariadb.service phpmyadmin-app.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
+EnvironmentFile=%S/state/secrets/root.secret
+EnvironmentFile=%S/state/secrets/phpmyadmin.secret
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/mariadb-app.pid %t/mariadb-app.ctr-id
@@ -16,12 +18,11 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/mariadb-app.pid \
     -v mysql-data:/var/lib/mysql/:Z -v mysql-conf.d:/etc/mysql/conf.d:Z \
     -v sql:/docker-entrypoint-initdb.d:Z \
     -v %S/scripts/create_admin_of_phpmyadmin.sql:/docker-entrypoint-initdb.d/create_admin.sql:Z \
-    -e MARIADB_ROOT_PASSWORD_FILE=/run/secrets/root.secret -e MARIADB_DATABASE=phpmyadmin \
-    -e MARIADB_USER=phpmyadmin -e MARIADB_PASSWORD_FILE=/run/secrets/phpmyadmin.secret \
-    --secret root.secret --secret phpmyadmin.secret \
+    -e MARIADB_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD} -e MARIADB_DATABASE=phpmyadmin \
+    -e MARIADB_USER=phpmyadmin -e MARIADB_PASSWORD=${MARIADB_PASSWORD} \
     ${MARIADB_IMAGE} \
     --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
-ExecStartPost=/usr/bin/podman exec  mariadb-app /bin/bash -c 'printf "[client] \npassword=$(cat /run/secrets/root.secret)" > /root/.my.cnf'
+ExecStartPost=/usr/bin/podman exec  mariadb-app /bin/bash -c 'printf "[client] \npassword=${MARIADB_ROOT_PASSWORD}" > /root/.my.cnf'
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/mariadb-app.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/mariadb-app.ctr-id
 PIDFile=%t/mariadb-app.pid

--- a/imageroot/systemd/user/mariadb-app.service
+++ b/imageroot/systemd/user/mariadb-app.service
@@ -6,8 +6,7 @@ After=mariadb.service phpmyadmin-app.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
-EnvironmentFile=%S/state/secrets/root.secret
-EnvironmentFile=%S/state/secrets/phpmyadmin.secret
+EnvironmentFile=%S/state/secrets/passwords.secret
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/mariadb-app.pid %t/mariadb-app.ctr-id

--- a/imageroot/systemd/user/mariadb-app.service
+++ b/imageroot/systemd/user/mariadb-app.service
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/mariadb-app.pid \
     --pod-id-file %t/mariadb.pod-id --replace -d --name mariadb-app \
     --env-file=%S/state/environment \
     -v mysql-data:/var/lib/mysql/:Z -v mysql-conf.d:/etc/mysql/conf.d:Z \
-    -v sql:/docker-entrypoint-initdb.d:Z \
+    -v sql:/docker-entrypoint-initdb.d:z \
     -v %S/scripts/create_admin_of_phpmyadmin.sql:/docker-entrypoint-initdb.d/create_admin.sql:Z \
     -e MARIADB_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD} -e MARIADB_DATABASE=phpmyadmin \
     -e MARIADB_USER=phpmyadmin -e MARIADB_PASSWORD=${MARIADB_PASSWORD} \

--- a/imageroot/systemd/user/phpmyadmin-app.service
+++ b/imageroot/systemd/user/phpmyadmin-app.service
@@ -6,6 +6,7 @@ After=mariadb.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
+EnvironmentFile=%S/state/secrets/phpmyadmin.secret
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/phpmyadmin-app.pid %t/phpmyadmin-app.ctr-id
@@ -14,8 +15,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/phpmyadmin-app.pid \
     --pod-id-file %t/mariadb.pod-id --replace -d --name phpmyadmin-app \
     --env-file=%S/state/environment -e PMA_HOST=127.0.0.1 -e PMA_PORT=3306 \
     -e PMA_PMADB=phpmyadmin -e PMA_CONTROLUSER=phpmyadmin \
-    -e PMA_CONTROLPASS_FILE=/run/secrets/phpmyadmin.secret \
-    --secret phpmyadmin.secret \
+    -e PMA_CONTROLPASS=${MARIADB_PASSWORD} \
     -v %S/scripts/create_phpmyadmin_web_alias.sh:/docker-entrypoint.d/create_phpmyadmin_web_alias.sh:Z \
     -v config.user.inc.php:/etc/phpmyadmin/config.user.inc.php:Z \
     -v sql:/var/www/html/sql:Z \

--- a/imageroot/systemd/user/phpmyadmin-app.service
+++ b/imageroot/systemd/user/phpmyadmin-app.service
@@ -6,7 +6,7 @@ After=mariadb.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
-EnvironmentFile=%S/state/secrets/phpmyadmin.secret
+EnvironmentFile=%S/state/secrets/passwords.secret
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/phpmyadmin-app.pid %t/phpmyadmin-app.ctr-id

--- a/imageroot/systemd/user/phpmyadmin-app.service
+++ b/imageroot/systemd/user/phpmyadmin-app.service
@@ -18,7 +18,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/phpmyadmin-app.pid \
     -e PMA_CONTROLPASS=${MARIADB_PASSWORD} \
     -v %S/scripts/create_phpmyadmin_web_alias.sh:/docker-entrypoint.d/create_phpmyadmin_web_alias.sh:Z \
     -v config.user.inc.php:/etc/phpmyadmin/config.user.inc.php:Z \
-    -v sql:/var/www/html/sql:Z \
+    -v sql:/var/www/html/sql:z \
     ${PHPMYADMIN_IMAGE}
 ExecStartPost=/usr/bin/podman exec  phpmyadmin-app /bin/bash /docker-entrypoint.d/create_phpmyadmin_web_alias.sh
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/phpmyadmin-app.ctr-id -t 10


### PR DESCRIPTION
Debian 11 runs podman 3.0.x and we need at minimal podman 3.1.x to use `podman secret`