### PR TITLE
retrieve the FQDN of the server by the agent library

### DIFF
--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -28,7 +28,6 @@ import os
 import sys
 import json
 import agent
-import socket
 
 # Prepare return variable
 config = {}

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -42,7 +42,7 @@ config["http2https"] =  rdb.hget(env, "TRAEFIK_HTTP2HTTPS") == "True";
 # config["lets_encrypt"] =  rdb.hget(env, "TRAEFIK_LETS_ENCRYPT") == "True";
 
 # Find the hostname of the node
-config["hostname"] = socket.gethostname()
+config["hostname"] = agent.get_hostname()
 
 # Dump the configuratio to stdou
 json.dump(config, fp=sys.stdout)


### PR DESCRIPTION
need to wait NethServer/ns8-core#427 is released

We need to find the fqdn of the server with the new function in agent