### PR TITLE
Add tips for changing admin login and unique PHPMyAdmin path

### DIFF
--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -39,7 +39,8 @@
     "phpmyadmin_url": "PhpMyAdmin web application",
     "link": "Link",
     "admin_login_tips": "The default login:password is admin:admin, you must change it at the first login",
-    "phpmyadmin_path_tips": "Enter a unique HTTP path, for example '/phpmyadmin'"
+    "phpmyadmin_path_tips": "Enter a unique HTTP path, for example '/phpmyadmin'",
+    "For_example": "For example"
   },
   "about": {
     "title": "About"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -38,7 +38,8 @@
     "configuring": "Configuring...",
     "phpmyadmin_url": "PhpMyAdmin web application",
     "link": "Link",
-    "admin_login_tips": "The default login:password is admin:admin, you must change it at the first login"
+    "admin_login_tips": "The default login:password is admin:admin, you must change it at the first login",
+    "phpmyadmin_path_tips": "Enter a unique HTTP path, for example '/phpmyadmin'"
   },
   "about": {
     "title": "About"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -1,7 +1,8 @@
 {
   "common": {
     "required": "Required",
-    "work_in_progress": "Work in progress"
+    "work_in_progress": "Work in progress",
+    "eg_value": "E.g. {value}"
   },
   "status": {
     "title": "Status",
@@ -39,8 +40,7 @@
     "phpmyadmin_url": "PhpMyAdmin web application",
     "link": "Link",
     "admin_login_tips": "The default login:password is admin:admin, you must change it at the first login",
-    "phpmyadmin_path_tips": "Enter a unique HTTP path, for example '/phpmyadmin'",
-    "For_example": "For example"
+    "phpmyadmin_path_tips": "Enter a unique HTTP path, for example '/phpmyadmin'"
   },
   "about": {
     "title": "About"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -21,7 +21,7 @@
           <cv-form @submit.prevent="configureModule">
             <NsTextInput
               :label="$t('settings.phpmyadmin_path')"
-              placeholder="e.g. /phpmyadmin"
+              :placeholder="$t('settings.For_example')+' /phpmyadmin'"
               v-model.trim="path"
               class="mg-bottom"
               :invalid-message="$t(error.path)"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -19,16 +19,27 @@
       <div class="bx--col-lg-16">
         <cv-tile :light="true">
           <cv-form @submit.prevent="configureModule">
-            <cv-text-input
+            <NsTextInput
               :label="$t('settings.phpmyadmin_path')"
-              placeholder="/phpmyadmin"
+              placeholder="e.g. /phpmyadmin"
               v-model.trim="path"
               class="mg-bottom"
               :invalid-message="$t(error.path)"
               :disabled="loading.getConfiguration || loading.configureModule"
               ref="path"
+              tooltipAlignment="center"
+              tooltipDirection="right"
             >
-            </cv-text-input>
+              <template slot="tooltip">
+                <div
+                  v-html="
+                    $t(
+                      'settings.phpmyadmin_path_tips'
+                    )
+                  "
+                ></div>
+              </template>
+            </NsTextInput>
             <template v-if="mariadb_tcp_port">
               <span class="mg-bottom">
                 {{ $t("settings.mariadb_tcp_port") }}

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -21,7 +21,7 @@
           <cv-form @submit.prevent="configureModule">
             <NsTextInput
               :label="$t('settings.phpmyadmin_path')"
-              :placeholder="$t('settings.For_example')+' /phpmyadmin'"
+              :placeholder="$t('common.eg_value', {value: '/sftpgo'})"
               v-model.trim="path"
               class="mg-bottom"
               :invalid-message="$t(error.path)"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -21,7 +21,7 @@
           <cv-form @submit.prevent="configureModule">
             <NsTextInput
               :label="$t('settings.phpmyadmin_path')"
-              :placeholder="$t('common.eg_value', {value: '/sftpgo'})"
+              :placeholder="$t('common.eg_value', {value: '/phpmyadmin'})"
               v-model.trim="path"
               class="mg-bottom"
               :invalid-message="$t(error.path)"


### PR DESCRIPTION
Previously, the admin login and PHPMyAdmin path were not clearly explained to users. This pull request adds helpful tips to guide users in changing the default login and setting a unique HTTP path for PHPMyAdmin.

![image](https://github.com/NethServer/ns8-mariadb/assets/3164851/c1294690-842b-4178-b4ca-e662f1c3f7e9)

![image](https://github.com/NethServer/ns8-mariadb/assets/3164851/22c1468e-39cf-4c85-b491-5a4b7c540615)
![image](https://github.com/NethServer/ns8-mariadb/assets/3164851/018b9c18-31a7-4a86-a69b-658706481498)
![image](https://github.com/NethServer/ns8-mariadb/assets/3164851/34df5b5f-15c6-4512-9cb0-92319660b4ed)

https://github.com/NethServer/dev/issues/6788