### PR TITLE
Add SSHLibrary and test cases for mariadb.robot

### DIFF
--- a/tests/__init__.robot
+++ b/tests/__init__.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+Library           SSHLibrary
+
+*** Variables ***
+${SSH_KEYFILE}    %{HOME}/.ssh/id_ecdsa
+
+*** Keywords ***
+Connect to the node
+    Open Connection   ${NODE_ADDR}
+    Login With Public Key    root    ${SSH_KEYFILE}
+    ${output} =    Execute Command    systemctl is-system-running  --wait
+    Should Be True    '${output}' == 'running' or '${output}' == 'degraded'
+
+*** Settings ***
+Suite Setup       Connect to the Node

--- a/tests/mariadb.robot
+++ b/tests/mariadb.robot
@@ -24,7 +24,7 @@ Check mariadb path is configured
     Should Be True         ${HTTP2HTTPS}
     Should Not Be Empty    ${UPLOAD}
 
-Check if posgresql works as expected
+Check if mariadb works as expected
     Wait Until Keyword Succeeds    20 times    3 seconds    Ping mariadb
 
 Check if mariadb is removed correctly


### PR DESCRIPTION
This pull request adds the SSHLibrary and test cases for mariadb.robot. The SSHLibrary is used to connect to a node and execute commands. The test cases ensure that the node is running properly by checking the output of the "systemctl is-system-running" command.