### PR TITLE
Restrict permissions of secrets files

### DIFF
--- a/imageroot/actions/create-module/02create_secrets
+++ b/imageroot/actions/create-module/02create_secrets
@@ -22,6 +22,9 @@
 
 set -e
 
+# restict to 400
+umask 266
+
 if [[ ! -d ~/.config/state/secrets ]]; then
     /usr/bin/mkdir -p ~/.config/state/secrets
 fi

--- a/imageroot/update-module.d/10FixPermissions
+++ b/imageroot/update-module.d/10FixPermissions
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+chmod 400 ./secrets/passwords.secret


### PR DESCRIPTION
This pull request includes changes to restrict the permissions of the `02create_secrets` script and the `passwords.secret` file. The `02create_secrets` script now sets the umask to 400, ensuring that the secrets directory is created with restricted permissions. Additionally, a new script `10FixPermissions` has been added to set the permissions of the `passwords.secret` file to 400. These changes enhance the security of the secrets files.


https://github.com/NethServer/dev/issues/6949