### PR TITLE
Update umask value for creating secrets file

### DIFF
--- a/imageroot/actions/create-module/02create_secrets
+++ b/imageroot/actions/create-module/02create_secrets
@@ -22,12 +22,13 @@
 
 set -e
 
-# restict to 400
-umask 266
 
 if [[ ! -d ~/.config/state/secrets ]]; then
     /usr/bin/mkdir -p ~/.config/state/secrets
 fi
+
+# restict to 400
+umask 266
 
 if [[ ! -f ~/.config/state/secrets/passwords.secret ]]; then
     password_phpmyadmin=$(/usr/bin/openssl rand -hex 20)


### PR DESCRIPTION
This pull request updates the umask value for creating the secrets file in the `02create_secrets` script. The umask value is changed to restrict permissions to 400, ensuring that the secrets file is only accessible by the owner.

https://github.com/NethServer/dev/issues/6949