### PR TITLE
Update @nethserver/ns8-ui-lib to version 1.1.4 and remove usage of v-html

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@carbon/icons-vue": "^10.37.0",
     "@carbon/vue": "^2.40.0",
-    "@nethserver/ns8-ui-lib": "^0.1.18",
+    "@nethserver/ns8-ui-lib": "^1.1.4",
     "await-to-js": "^3.0.0",
     "axios": "^0.21.2",
     "carbon-components": "^10.41.0",

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -21,7 +21,7 @@
           <cv-form @submit.prevent="configureModule">
             <NsTextInput
               :label="$t('settings.phpmyadmin_path')"
-              :placeholder="$t('common.eg_value', {value: '/phpmyadmin'})"
+              :placeholder="$t('common.eg_value', { value: '/phpmyadmin' })"
               v-model.trim="path"
               class="mg-bottom"
               :invalid-message="$t(error.path)"
@@ -31,13 +31,7 @@
               tooltipDirection="right"
             >
               <template slot="tooltip">
-                <div
-                  v-html="
-                    $t(
-                      'settings.phpmyadmin_path_tips'
-                    )
-                  "
-                ></div>
+                <div>{{ $t("settings.phpmyadmin_path_tips") }}</div>
               </template>
             </NsTextInput>
             <template v-if="mariadb_tcp_port">
@@ -129,13 +123,7 @@
               max="256"
             >
               <template slot="tooltip">
-                <div
-                  v-html="
-                    $t(
-                      'settings.upload_limit_tips'
-                    )
-                  "
-                ></div>
+                <div>{{ $t("settings.upload_limit_tips") }}</div>
               </template>
             </NsTextInput>
             <NsButton

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1012,10 +1012,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nethserver/ns8-ui-lib@^0.1.18":
-  version "0.1.18"
-  resolved "https://registry.yarnpkg.com/@nethserver/ns8-ui-lib/-/ns8-ui-lib-0.1.18.tgz#3797a8df666a6826fefa8fe4ea56404e395dca85"
-  integrity sha512-aQn8AtrYX2GMextcHVn3tosNh0839GEyDjGiWYQi4lamb4CkI/nFDp8zwY8Iku6tg5Qbs1VV4ebf70U14ggtdg==
+"@nethserver/ns8-ui-lib@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.npmmirror.com/@nethserver/ns8-ui-lib/-/ns8-ui-lib-1.1.4.tgz#6e8a47356c43773527c2d410e907c3dbe41326e2"
+  integrity sha512-z5lpixFPFlhBejMIYOFG6+YS74wcoppg1bat3WM1HTVo5gmpE3GVMOOIz+A2ThO9S/4ecWs6LG/GT/syQI2k5A==
   dependencies:
     "@rollup/plugin-json" "^4.1.0"
     core-js "^3.15.2"


### PR DESCRIPTION
This pull request updates the `@nethserver/ns8-ui-lib` dependency to version 1.1.4 and removes the usage of `v-html` in the `Settings.vue` file. The update ensures that the latest version of the dependency is used, which may include bug fixes or new features. The removal of `v-html` improves security by preventing potential cross-site scripting vulnerabilities.