### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/mariadb-app.service
+++ b/imageroot/systemd/user/mariadb-app.service
@@ -5,18 +5,18 @@ After=mariadb.service phpmyadmin-app.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-EnvironmentFile=%S/state/secrets/passwords.secret
+EnvironmentFile=%E/state/environment
+EnvironmentFile=%E/state/secrets/passwords.secret
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/mariadb-app.pid %t/mariadb-app.ctr-id
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/mariadb-app.pid \
     --cidfile %t/mariadb-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/mariadb.pod-id --replace -d --name mariadb-app \
-    --env-file=%S/state/environment \
+    --env-file=%E/state/environment \
     -v mysql-data:/var/lib/mysql/:Z -v mysql-conf.d:/etc/mysql/conf.d:Z \
     -v sql:/docker-entrypoint-initdb.d:z \
-    -v %S/scripts/create_admin_of_phpmyadmin.sql:/docker-entrypoint-initdb.d/create_admin.sql:Z \
+    -v %E/scripts/create_admin_of_phpmyadmin.sql:/docker-entrypoint-initdb.d/create_admin.sql:Z \
     -e MARIADB_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD} -e MARIADB_DATABASE=phpmyadmin \
     -e MARIADB_USER=phpmyadmin -e MARIADB_PASSWORD=${MARIADB_PASSWORD} \
     -e MARIADB_AUTO_UPGRADE=1 \

--- a/imageroot/systemd/user/mariadb.service
+++ b/imageroot/systemd/user/mariadb.service
@@ -5,7 +5,7 @@ Before=mariadb-app.service phpmyadmin-app.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=-%S/state/environment
+EnvironmentFile=-%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/mariadb.pid %t/mariadb.pod-id

--- a/imageroot/systemd/user/phpmyadmin-app.service
+++ b/imageroot/systemd/user/phpmyadmin-app.service
@@ -5,18 +5,18 @@ After=mariadb.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-EnvironmentFile=%S/state/secrets/passwords.secret
+EnvironmentFile=%E/state/environment
+EnvironmentFile=%E/state/secrets/passwords.secret
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/phpmyadmin-app.pid %t/phpmyadmin-app.ctr-id
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/phpmyadmin-app.pid \
     --cidfile %t/phpmyadmin-app.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/mariadb.pod-id --replace -d --name phpmyadmin-app \
-    --env-file=%S/state/environment -e PMA_HOST=127.0.0.1 -e PMA_PORT=3306 \
+    --env-file=%E/state/environment -e PMA_HOST=127.0.0.1 -e PMA_PORT=3306 \
     -e PMA_PMADB=phpmyadmin -e PMA_CONTROLUSER=phpmyadmin \
     -e PMA_CONTROLPASS=${MARIADB_PASSWORD} \
-    -v %S/scripts/create_phpmyadmin_web_alias.sh:/docker-entrypoint.d/create_phpmyadmin_web_alias.sh:Z \
+    -v %E/scripts/create_phpmyadmin_web_alias.sh:/docker-entrypoint.d/create_phpmyadmin_web_alias.sh:Z \
     -v config.user.inc.php:/etc/phpmyadmin/config.user.inc.php:Z \
     -v sql:/var/www/html/sql:z \
     ${PHPMYADMIN_IMAGE}


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host